### PR TITLE
add consent-gated detection sketch and privacy docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sessions/
 *.mp4
 .DS_Store
 Thumbs.db
+processing/ConsentDetect/captures/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-
 # Changelog
+
+## v2.1
+- Added ConsentDetect teaching sketch (consent gate, TTL, overlay toggle)
+- Added privacy/ethics docs and auto-purge on startup
 
 ## v2 (current)
 - Added Arduino **long-press** → `CONSENT_TOGGLE`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+title: "faceTimes"
+message: "If you use this repo, cite it punk-style."
+authors:
+  - family-names: Doe
+    given-names: Jane
+    orcid: "0000-0000-0000-0000"
+release-date: 2024-01-01
+version: "0.1.0"

--- a/ETHICS.md
+++ b/ETHICS.md
@@ -1,0 +1,8 @@
+# Ethics
+
+- consent is a switch, not a footnote
+- detection ≠ recognition; we draw boxes, we don't name people
+- all work stays on-device; air-gapped is the vibe
+- users choose save or discard every time
+- retention is temporary by design; automation wipes leftovers
+- known limits: cascades miss faces under hats, weird light, or at angles

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,11 @@
+# Privacy
+
+This repo ships sketches that keep it local:
+
+- detection-only: no face IDs, no embeddings
+- camera stays off until you say **Yes**
+- preview lives in RAM; nothing hits disk unless you smash save
+- saved pics carry an `expiresAt`; old files nuke themselves on launch
+- no network calls, no analytics, no surprises
+
+Want a file gone now? trash the `captures/` folder.

--- a/docs/assumption-ledger.md
+++ b/docs/assumption-ledger.md
@@ -1,0 +1,6 @@
+# Assumption Ledger
+- Model: OpenCV HAAR frontal face default
+- Thresholds: library defaults
+- Failure cases: side profiles, masks, harsh backlight
+- Never do: send images off-box, store without consent, add recognition
+- Purge schedule: on startup, delete expired captures (>30 days)

--- a/docs/lineage.md
+++ b/docs/lineage.md
@@ -1,0 +1,4 @@
+# Lineage
+- 2023: first face-slug mashups
+- 2024: consent-gated composites with Arduino buttons
+- 2025: this repo splits out a tiny, detection-only sketch for classrooms

--- a/docs/sketchbook/index.md
+++ b/docs/sketchbook/index.md
@@ -1,0 +1,3 @@
+# Sketchbook
+- FaceSlugPrivacyTeaching.pde — big demo with avatars and recording
+- ConsentDetect.pde — stripped-down consent-first detector for teaching

--- a/processing/ConsentDetect/ConsentDetect.pde
+++ b/processing/ConsentDetect/ConsentDetect.pde
@@ -1,0 +1,180 @@
+/**
+ * Consent-Gated Face Detector
+ * ---------------------------
+ * Minimal teaching sketch showing a privacy-first pipeline:
+ * consent before camera, detection-only, TTL storage, and an overlay toggle.
+ * <p>
+ * Lots of inline comments below so learners can follow the data flow
+ * and adapt it for their own experiments.
+ *
+ * Build: v0.1.0
+ */
+
+import processing.video.*;
+import gab.opencv.*;
+import java.io.File;
+import java.util.UUID;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import processing.data.JSONObject;
+
+Capture cam;
+OpenCV opencv;
+
+// State machine: we start at CONSENT, then show PREVIEW once the user opts in,
+// and finally REVIEW when a frame has been captured and awaits a decision.
+String state = "CONSENT"; // CONSENT -> PREVIEW -> REVIEW
+
+// Overlay toggle for "See the math"; default is off to keep things chill.
+boolean showOverlay = false;
+
+// Holds the captured frame while we ask the user to save or toss it.
+PImage reviewFrame;
+
+// Handles saving and purging images with expiration metadata.
+StorageManager storage = new StorageManager();
+
+final String BUILD = "v0.1.0";
+
+void settings() {
+  size(640, 480); // fixed window size keeps math simple
+}
+
+void setup() {
+  surface.setTitle("Consent-Gated Face Detector");
+  // Clean out any expired captures from prior runs before we do anything else.
+  storage.purgeExpired();
+}
+
+void draw() {
+  background(0); // blank slate every frame
+
+  // Route to the correct screen based on our current state.
+  if (state.equals("CONSENT")) { drawConsent(); return; }
+  if (state.equals("PREVIEW")) { drawPreview(); return; }
+  if (state.equals("REVIEW"))  { drawReview();  return; }
+}
+
+void drawConsent() {
+  fill(255);
+  textAlign(CENTER, CENTER);
+  // Simple prompt: nothing happens until the user hits "y".
+  text("Start camera?", width/2, height/2 - 20);
+  text("[y]es  |  [n]o", width/2, height/2 + 20);
+  drawStatus();
+}
+
+void drawPreview() {
+  // Pull the next frame if it's ready.
+  if (cam.available()) cam.read();
+  image(cam, 0, 0); // dump the raw camera feed to the screen
+
+  // Run face detection entirely in RAM—no disk writes here.
+  opencv.loadImage(cam);
+  Rectangle[] faces = opencv.detect();
+
+  // Optionally draw green rectangles so students can "see the math".
+  if (showOverlay) {
+    noFill(); stroke(0,255,0);
+    for (Rectangle r : faces) rect(r.x, r.y, r.width, r.height);
+  }
+
+  drawStatus();
+}
+
+void drawReview() {
+  // Freeze the captured frame and dim it so the prompt pops.
+  image(reviewFrame, 0, 0);
+  fill(0,150);
+  rect(0,0,width,height);
+  fill(255);
+  textAlign(CENTER,CENTER);
+  text("Save image? y/n", width/2, height/2);
+  drawStatus();
+}
+
+void keyPressed() {
+  // Key handling is state-aware so we don't accidentally trigger actions.
+  if (state.equals("CONSENT")) {
+    if (key=='y' || key=='Y') startCamera(); // user opts in
+    if (key=='n' || key=='N') exit();         // user bails
+  } else if (state.equals("PREVIEW")) {
+    if (key==' ') captureFrame();              // snapshot for review
+    if (key=='o' || key=='O') showOverlay = !showOverlay; // toggle math overlay
+  } else if (state.equals("REVIEW")) {
+    if (key=='y' || key=='Y') saveReview();   // commit to disk with TTL
+    if (key=='n' || key=='N') state = "PREVIEW"; // toss and resume preview
+  }
+}
+
+void startCamera() {
+  // Camera springs to life only after explicit consent.
+  cam = new Capture(this, 640, 480);
+  cam.start();
+
+  // Load the classic Haar cascade—fast, simple, and good for demos.
+  opencv = new OpenCV(this, 640, 480);
+  opencv.loadCascade(OpenCV.CASCADE_FRONTALFACE);
+
+  state = "PREVIEW"; // start streaming frames
+}
+
+void captureFrame() {
+  // Grab the current frame so the user can mull it over.
+  reviewFrame = cam.get();
+  state = "REVIEW";
+}
+
+void saveReview() {
+  // Save the image to disk along with its expiration metadata.
+  storage.saveWithTTL(reviewFrame);
+  state = "PREVIEW"; // then hop back to the live feed
+}
+
+void drawStatus() {
+  // Footer keeps us transparent about what's happening.
+  fill(255);
+  textSize(12);
+  textAlign(LEFT, BOTTOM);
+  text(BUILD + "  ·  Camera → Detect (RAM) → Save/Discard", 5, height-5);
+}
+
+/**
+ * Handles saving images with a time-to-live and purging expired files.
+ */
+class StorageManager {
+  final File dir = new File(sketchPath("captures")); // where images live
+  final int retentionDays = 30;                        // TTL in days
+  StorageManager() { dir.mkdirs(); }
+
+  /** Deletes expired images based on sidecar metadata. */
+  void purgeExpired() {
+    // Look for PNGs; if they have a JSON sibling with an old expiresAt, delete.
+    File[] imgs = dir.listFiles((d,n)->n.toLowerCase().endsWith(".png"));
+    if (imgs == null) return;
+    for (File f : imgs) {
+      File meta = new File(f.getAbsolutePath()+".json");
+      if (!meta.exists()) continue; // missing metadata? keep but note the smell
+      JSONObject obj = loadJSONObject(meta);
+      long exp = obj.getLong("expiresAt");
+      if (exp < System.currentTimeMillis()) {
+        f.delete();
+        meta.delete();
+      }
+    }
+  }
+
+  /** Saves an image alongside expiration metadata. */
+  void saveWithTTL(PImage img) {
+    dir.mkdirs();
+    String id = UUID.randomUUID().toString();
+    String path = new File(dir, id + ".png").getAbsolutePath();
+    img.save(path);
+
+    // Sidecar JSON holds the expiration timestamp for purgeExpired().
+    JSONObject meta = new JSONObject();
+    long ttl = System.currentTimeMillis() + retentionDays*24L*3600L*1000L;
+    meta.setLong("expiresAt", ttl);
+    saveJSONObject(meta, path + ".json");
+  }
+}

--- a/processing/ConsentDetect/README.md
+++ b/processing/ConsentDetect/README.md
@@ -1,0 +1,11 @@
+# ConsentDetect
+**What this tests:** consent gate + face detection with TTL saves
+**Learning goals:**
+- cameras stay dark until you say yes
+- detection boxes show math, not identity
+- review the capture and decide if it lives or dies
+**Run:** Processing 4 (Java mode). Open this folder and hit **Run**.
+**Dependencies:** Video library, OpenCV for Processing
+**Controls:** `space` capture → review; `y`/`n` save or toss; `o` toggle "See the math"
+**Known limits:** single USB cam, front-facing cascade only, PNG output
+**Ethics:** detection only; no recognition; stays offline; images auto-expire


### PR DESCRIPTION
## Summary
- add minimal ConsentDetect sketch featuring consent gate, TTL storage and overlay toggle
- document privacy/ethics and project lineage for learners
- annotate ConsentDetect sketch with verbose comments for easier teaching

## Testing
- `processing-java --sketch=processing/ConsentDetect --build` *(fails: command not found)*
- `rg -n "HttpURLConnection|URLConnection|OkHttpClient|WebView|URL\(" || true`
- `rg -n "FaceRecognizer|LBPH|computeFaceDescriptor|embedding" -i || true`


------
https://chatgpt.com/codex/tasks/task_e_68c5fc1d99e88325b0c236e5f76672ec