### PR TITLE
Fix mermaid diagrams rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ face-slug-privacy-teaching/
 ## Data-flow (high level)
 
 ```mermaid
-flowchart LR
+graph LR
     C(Camera) --> D[Detect (RAM)]
     D --> R{Review}
     R -- Save --> PNG[Write PNG]
@@ -76,20 +76,20 @@ sequenceDiagram
   participant Host as Processing Sketch
 
   BTN->>MCU: Press SAVE
-  MCU->>Host: "SAVE"
+  MCU->>Host: SAVE
   Host->>Host: Capture preview (RAM); open Review
 
-  BTN->>MCU: Second press (≤ 1s)
-  MCU->>Host: "SAVE_DBL"
+  BTN->>MCU: Second press (<= 1s)
+  MCU->>Host: SAVE_DBL
   alt Consent ON
     Host->>FS: Save PNG immediately
   else Consent OFF
     Host->>Host: Remain in Review; prompt for consent
   end
 
-  BTN->>MCU: Long-press SAVE (≥1.5s)
-  MCU->>Host: "CONSENT_TOGGLE"
-  Host->>Host: Consent flips ON↔OFF
+  BTN->>MCU: Long-press SAVE (>= 1.5s)
+  MCU->>Host: CONSENT_TOGGLE
+  Host->>Host: Consent flips ON <-> OFF
 ```
 
 ## License

--- a/diagrams.md
+++ b/diagrams.md
@@ -7,9 +7,9 @@
 stateDiagram-v2
   [*] --> Idle
   Idle --> Review : SAVE (first press)
-  Review --> Saved : SAVE_DBL (≤1s) / Consent ON
+  Review --> Saved : SAVE_DBL (<= 1s) / Consent ON
   Review --> Review : SAVE_DBL / Consent OFF
-  Review --> Saved : "Save" button (Consent ON)
+  Review --> Saved : Save button (Consent ON)
   Review --> Idle  : Discard
   Saved --> Idle
 ```
@@ -17,7 +17,7 @@ stateDiagram-v2
 ## B. Recording lifecycle (consent + face-gate)
 
 ```mermaid
-flowchart LR
+graph LR
   A[REC toggle ON] --> B{Consent ON?}
   B -- no --> A
   B -- yes --> C{Gate on face?}
@@ -36,7 +36,7 @@ flowchart LR
 ## C. Data pipeline
 
 ```mermaid
-flowchart LR
+graph LR
   Cam(Camera) --> CV[OpenCV Detect]
   CV --> Comp[Composite over Slug]
   Comp --> UI[UI Overlays (buttons/map/toasts)]


### PR DESCRIPTION
## Summary
- update README and diagrams to use `graph` declarations so Mermaid renders reliably
- remove smart characters in diagram labels for better parser compatibility

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9b36677d4832592a5f4a794ca74f9