### PR TITLE
Fix mermaid diagrams rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ flowchart LR
     D --> R{Review}
     R -- Save --> PNG[Write PNG]
     R -- Discard --> X1[(No file)]
-    subgraph Session Recording
+    subgraph "Session Recording"
       SR(REC ON) -->|Consent & optional face-gate| FW[Write frames]
       SR -->|Stop| RS{Session Review}
       RS -- Keep --> MP4[Keep MP4]
@@ -74,12 +74,13 @@ sequenceDiagram
   participant BTN as Arduino Button
   participant MCU as Arduino
   participant Host as Processing Sketch
+  participant FS as FileSystem
 
   BTN->>MCU: Press SAVE
   MCU->>Host: "SAVE"
   Host->>Host: Capture preview (RAM); open Review
 
-  BTN->>MCU: Second press (≤ 1s)
+  BTN->>MCU: Second press (<= 1s)
   MCU->>Host: "SAVE_DBL"
   alt Consent ON
     Host->>FS: Save PNG immediately
@@ -87,9 +88,9 @@ sequenceDiagram
     Host->>Host: Remain in Review; prompt for consent
   end
 
-  BTN->>MCU: Long-press SAVE (≥1.5s)
+  BTN->>MCU: Long-press SAVE (>=1.5s)
   MCU->>Host: "CONSENT_TOGGLE"
-  Host->>Host: Consent flips ON↔OFF
+  Host->>Host: Consent flips ON<->OFF
 ```
 
 ## License

--- a/diagrams.md
+++ b/diagrams.md
@@ -7,9 +7,9 @@
 stateDiagram-v2
   [*] --> Idle
   Idle --> Review : SAVE (first press)
-  Review --> Saved : SAVE_DBL (≤1s) / Consent ON
+  Review --> Saved : SAVE_DBL (<=1s) / Consent ON
   Review --> Review : SAVE_DBL / Consent OFF
-  Review --> Saved : "Save" button (Consent ON)
+  Review --> Saved : Save button (Consent ON)
   Review --> Idle  : Discard
   Saved --> Idle
 ```


### PR DESCRIPTION
## Summary
- wrap the session recording subgraph label in quotes for proper mermaid parsing
- declare the filesystem participant and normalize ascii symbols in the README sequence diagram
- clean up the state diagram labels in diagrams.md so mermaid stops choking on quotes and unicode

## Testing
- no tests needed (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c9b36677d4832592a5f4a794ca74f9