### PR TITLE
Fix mermaid flowcharts in diagrams

### DIFF
--- a/diagrams.md
+++ b/diagrams.md
@@ -17,27 +17,27 @@ stateDiagram-v2
 ## B. Recording lifecycle (consent + face-gate)
 
 ```mermaid
-graph LR
+flowchart TD
   A[REC toggle ON] --> B{Consent ON?}
-  B -- no --> A
-  B -- yes --> C{Gate on face?}
-  C -- no --> D[Write frames every draw()]
-  C -- yes --> E{Face present?}
-  E -- yes --> D
-  E -- no --> A
+  B -- "no" --> A
+  B -- "yes" --> C{Gate on face?}
+  C -- "no" --> D[Write frames every draw()]
+  C -- "yes" --> E{Face present?}
+  E -- "yes" --> D
+  E -- "no" --> A
   D --> F[REC toggle OFF]
   F --> G{Frames written > 0?}
-  G -- no --> H[Delete empty MP4]
-  G -- yes --> I[Session Review Keep/Discard]
-  I -- Keep --> J[Keep MP4]
-  I -- Discard/Timeout --> H
+  G -- "no" --> H[Delete empty MP4]
+  G -- "yes" --> I[Session Review Keep/Discard]
+  I -- "Keep" --> J[Keep MP4]
+  I -- "Discard/Timeout" --> H
 ```
 
 ## C. Data pipeline
 
 ```mermaid
-graph LR
-  Cam(Camera) --> CV[OpenCV Detect]
+flowchart LR
+  Cam([Camera]) --> CV[OpenCV Detect]
   CV --> Comp[Composite over Slug]
   Comp --> UI[UI Overlays (buttons/map/toasts)]
   UI -->|Consent-gated| Disk[(Disk PNG/MP4)]


### PR DESCRIPTION
## Summary
- switch the recording lifecycle diagram to the modern `flowchart` directive and quote edge labels so it renders cleanly
- update the data pipeline diagram to use `flowchart` syntax and a standard node definition so the renderer recognizes each node

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc0b5e76308325b880d65b30687d35