### PR TITLE
Fix Mermaid diagrams for GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ face-slug-privacy-teaching/
 
 ```mermaid
 graph LR
-    C(Camera) --> D[Detect (RAM)]
+    C[(Camera)] --> D["Detect in RAM"]
     D --> R{Review}
-    R -- Save --> PNG[Write PNG]
+    R -- Save --> PNG[[Write PNG]]
     R -- Discard --> X1[(No file)]
     subgraph "Session Recording"
-      SR(REC ON) -->|Consent & optional face-gate| FW[Write frames]
-      SR -->|Stop| RS{Session Review}
-      RS -- Keep --> MP4[Keep MP4]
+      SR([REC ON]) -->|Consent + optional gate| FW[[Write frames]]
+      SR -->|Stop| RS{Session review}
+      RS -- Keep --> MP4[[Keep MP4]]
       RS -- Discard/Timeout --> X2[(Delete MP4)]
     end
 ```
@@ -88,19 +88,20 @@ sequenceDiagram
 
   BTN->>MCU: Press SAVE
   MCU->>Host: SAVE
-  Host->>Host: Capture preview (RAM); open Review
+  Host->>Host: Capture preview in RAM
+  Host->>Host: Open review overlay
 
   BTN->>MCU: Second press (<= 1s)
   MCU->>Host: SAVE_DBL
   alt Consent ON
     Host->>FS: Save PNG immediately
   else Consent OFF
-    Host->>Host: Remain in Review; prompt for consent
+    Host->>Host: Remain in review and prompt for consent
   end
 
   BTN->>MCU: Long-press SAVE (>= 1.5s)
   MCU->>Host: CONSENT_TOGGLE
-  Host->>Host: Consent flips ON <-> OFF
+  Host->>Host: Flip consent state
 ```
 
 ## License

--- a/diagrams.md
+++ b/diagrams.md
@@ -18,18 +18,29 @@ stateDiagram-v2
 
 ```mermaid
 flowchart LR
-  start([REC toggle ON]) --> consent{Consent ON?}
+  start([REC toggle ON])
+  consent{Consent ON?}
+  gate{Gate on face?}
+  present{Face present?}
+  writer["Write frames every draw()"]
+  stop([REC toggle OFF])
+  written{Frames written > 0?}
+  review{"Session Review"\nKeep or Discard}
+  keep[[Keep MP4]]
+  delete[[Delete empty MP4]]
+
+  start --> consent
   consent -- No --> start
-  consent -- Yes --> gate{Gate on face?}
-  gate -- No --> writer[Write frames every draw()]
-  gate -- Yes --> present{Face present?}
+  consent -- Yes --> gate
+  gate -- No --> writer
+  gate -- Yes --> present
   present -- Yes --> writer
   present -- No --> start
-  writer --> stop([REC toggle OFF])
-  stop --> written{Frames written > 0?}
-  written -- No --> delete[Delete empty MP4]
-  written -- Yes --> review{Session Review Keep/Discard}
-  review -- Keep --> keep[Keep MP4]
+  writer --> stop
+  stop --> written
+  written -- No --> delete
+  written -- Yes --> review
+  review -- Keep --> keep
   review -- Discard/Timeout --> delete
 ```
 
@@ -37,10 +48,10 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  camera[[Camera]] --> detect[OpenCV Detect]
-  detect --> composite[Composite over Slug]
-  composite --> ui[UI Overlays (buttons/map/toasts)]
-  ui -->|Consent-gated| disk[(Disk PNG/MP4)]
+  camera[[Camera]] --> detect["OpenCV Detect"]
+  detect --> composite["Composite over slug"]
+  composite --> ui["UI overlays"\nbuttons / map / toasts]
+  ui -->|Consent gated| disk[(Disk PNG/MP4)]
 ```
 
 ## D. Serial interactions
@@ -52,7 +63,7 @@ sequenceDiagram
   participant FS as FileSystem
 
   Arduino->>Processing: SAVE
-  Processing->>Processing: Open Review overlay (RAM only)
+  Processing->>Processing: Open review overlay (RAM only)
 
   Arduino->>Processing: SAVE_DBL
   alt Consent ON


### PR DESCRIPTION
## Summary
- rewrite the recording lifecycle and data pipeline flowcharts with explicit node declarations to satisfy GitHub's Mermaid parser
- clean up sequence diagram copy to avoid unsupported punctuation and clarify review steps in both diagrams.md and README.md

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc0de8980c8325bd1f134770542826