### PR TITLE
Fix Mermaid diagrams for GitHub renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ face-slug-privacy-teaching/
 
 ```mermaid
 graph LR
-    C(Camera) --> D[Detect (RAM)]
-    D --> R{Review}
-    R -- Save --> PNG[Write PNG]
-    R -- Discard --> X1[(No file)]
-    subgraph "Session Recording"
-      SR(REC ON) -->|Consent & optional face-gate| FW[Write frames]
-      SR -->|Stop| RS{Session Review}
-      RS -- Keep --> MP4[Keep MP4]
-      RS -- Discard/Timeout --> X2[(Delete MP4)]
+    camera[Camera] --> detect[Detect in RAM]
+    detect --> review{Review}
+    review -->|Save| png[Write PNG]
+    review -->|Discard| nofile[No file]
+    subgraph "Session recording"
+      rec_on([REC toggle on]) -->|Consent and optional face gate| writer[Write frames]
+      rec_on -->|Stop| session_review{Session review}
+      session_review -->|Keep| mp4[Keep MP4]
+      session_review -->|Discard or timeout| delete_mp4[Delete MP4]
     end
 ```
 
@@ -88,19 +88,20 @@ sequenceDiagram
 
   BTN->>MCU: Press SAVE
   MCU->>Host: SAVE
-  Host->>Host: Capture preview (RAM); open Review
+  Host->>Host: Capture preview in RAM
+  Host->>Host: Open review overlay
 
-  BTN->>MCU: Second press (<= 1s)
+  BTN->>MCU: Second press within one second
   MCU->>Host: SAVE_DBL
   alt Consent ON
     Host->>FS: Save PNG immediately
   else Consent OFF
-    Host->>Host: Remain in Review; prompt for consent
+    Host->>Host: Stay in review and prompt for consent
   end
 
-  BTN->>MCU: Long-press SAVE (>= 1.5s)
+  BTN->>MCU: Long press SAVE for at least 1.5 s
   MCU->>Host: CONSENT_TOGGLE
-  Host->>Host: Consent flips ON <-> OFF
+  Host->>Host: Flip consent state
 ```
 
 ## License

--- a/diagrams.md
+++ b/diagrams.md
@@ -17,30 +17,30 @@ stateDiagram-v2
 ## B. Recording lifecycle (consent + face-gate)
 
 ```mermaid
-flowchart LR
-  start([REC toggle ON]) --> consent{Consent ON?}
-  consent -- No --> start
-  consent -- Yes --> gate{Gate on face?}
-  gate -- No --> writer[Write frames every draw()]
-  gate -- Yes --> present{Face present?}
-  present -- Yes --> writer
-  present -- No --> start
-  writer --> stop([REC toggle OFF])
-  stop --> written{Frames written > 0?}
-  written -- No --> delete[Delete empty MP4]
-  written -- Yes --> review{Session Review Keep/Discard}
-  review -- Keep --> keep[Keep MP4]
-  review -- Discard/Timeout --> delete
+graph LR
+  start([REC toggle on]) --> consent{Consent on?}
+  consent -->|No| start
+  consent -->|Yes| gate{Face gate enabled?}
+  gate -->|No| writer[Write frames each draw]
+  gate -->|Yes| present{Face detected?}
+  present -->|Yes| writer
+  present -->|No| start
+  writer --> stop([REC toggle off])
+  stop --> written{Frames written > zero?}
+  written -->|No| delete[Delete empty MP4]
+  written -->|Yes| review{Session review keep or discard}
+  review -->|Keep| keep[Keep MP4]
+  review -->|Discard or timeout| delete
 ```
 
 ## C. Data pipeline
 
 ```mermaid
-flowchart LR
-  camera[[Camera]] --> detect[OpenCV Detect]
-  detect --> composite[Composite over Slug]
-  composite --> ui[UI Overlays (buttons/map/toasts)]
-  ui -->|Consent-gated| disk[(Disk PNG/MP4)]
+graph LR
+  camera[Camera feed] --> detect[OpenCV detect]
+  detect --> composite[Composite with slug art]
+  composite --> ui[UI overlays buttons map toasts]
+  ui -->|Consent gate| disk[Disk PNG or MP4]
 ```
 
 ## D. Serial interactions


### PR DESCRIPTION
## Summary
- simplify README dataflow mermaid chart so GitHub can parse it cleanly
- rewrite README serial protocol steps into single-line sequence messages for renderer compatibility
- align diagrams.md flowcharts with the same low-friction Mermaid syntax to restore the gallery

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cc0de8980c8325bd1f134770542826