### PR TITLE
Tighten SAVE button gesture handling

### DIFF
--- a/arduino/SaveRecDoubleLongPress/SaveRecDoubleLongPress.ino
+++ b/arduino/SaveRecDoubleLongPress/SaveRecDoubleLongPress.ino
@@ -4,14 +4,17 @@
 const int BTN_SAVE = 2;  // short: SAVE, double (≤1s): SAVE_DBL, long (≥1.5s): CONSENT_TOGGLE
 const int BTN_REC  = 3;  // REC toggle
 
-const unsigned long DOUBLE_MS = 1000;   // double-press window
+const unsigned long DOUBLE_MS = 1000;   // double-press window (single fires after this expires)
 const unsigned long LONG_MS   = 1500;   // long-press threshold
 
 // SAVE button FSM
 bool saveDown = false;
 unsigned long saveDownAt = 0;
-unsigned long lastShortPressAt = 0;
+
+// Short press gets queued until the double-tap window expires.
+unsigned long pendingStartedAt = 0;
 bool pendingSingle = false;
+
 bool longFired = false;
 
 void setup() {
@@ -24,43 +27,44 @@ void loop() {
   static bool prevSave = HIGH, prevRec = HIGH;
   bool curSave = digitalRead(BTN_SAVE);
   bool curRec  = digitalRead(BTN_REC);
+  unsigned long now = millis();
 
   // --- SAVE button state machine ---
   if (prevSave == HIGH && curSave == LOW) {
     // press
     saveDown = true;
     longFired = false;
-    saveDownAt = millis();
+    saveDownAt = now;
   }
 
   if (saveDown) {
-    unsigned long held = millis() - saveDownAt;
+    unsigned long held = now - saveDownAt;
     if (!longFired && held >= LONG_MS) {
       // Long-press: CONSENT_TOGGLE, consume gesture (no SAVE messages)
       Serial.println("CONSENT_TOGGLE");
       longFired = true;
       pendingSingle = false; // cancel pending single
     }
-    if (prevSave == LOW && curSave == HIGH) {
-      // release
-      saveDown = false;
-      if (!longFired) {
-        // Short press path (consider double)
-        unsigned long now = millis();
-        if (pendingSingle && (now - lastShortPressAt) <= DOUBLE_MS) {
-          Serial.println("SAVE_DBL");    // explicit double
-          pendingSingle = false;
-        } else {
-          Serial.println("SAVE");        // first tap
-          pendingSingle = true;
-          lastShortPressAt = now;
-        }
+  }
+
+  if (prevSave == LOW && curSave == HIGH) {
+    // release
+    saveDown = false;
+    if (!longFired) {
+      if (pendingSingle && (now - pendingStartedAt) <= DOUBLE_MS) {
+        Serial.println("SAVE_DBL");    // explicit double
+        pendingSingle = false;
+      } else {
+        pendingSingle = true;          // wait to see if a second tap arrives
+        pendingStartedAt = now;
       }
     }
   }
 
-  // timeout a lone first tap if no second tap arrives
-  if (pendingSingle && (millis() - lastShortPressAt) > DOUBLE_MS) {
+  // If a pending single press ages out, emit the SAVE now.
+  // This keeps doubles from spamming a SAVE + SAVE_DBL pair.
+  if (pendingSingle && (now - pendingStartedAt) > DOUBLE_MS) {
+    Serial.println("SAVE");
     pendingSingle = false;
   }
 


### PR DESCRIPTION
## Summary
- rework the Arduino SAVE button state machine so a single tap queues until the double-press window expires
- ensure explicit double presses emit only SAVE_DBL while long presses cancel any pending single
- reuse a shared millis() timestamp inside loop for consistent gesture timing

## Testing
- not run (arduino build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc493c147c8325a38b9aaefa1ed281