### PR TITLE
Fix newline char literal in serial buffer setup

### DIFF
--- a/processing/FaceSlugPrivacyTeaching.pde
+++ b/processing/FaceSlugPrivacyTeaching.pde
@@ -533,12 +533,12 @@ void setupSerial() {
   for (int i=0;i<ports.length;i++) if (ports[i].toLowerCase().matches(".*(" + SERIAL_HINT + ").*")) { pick=i; break; }
   if (pick==-1) pick=0;
   println("Connecting to: " + ports[pick]);
-  try { ard = new Serial(this, ports[pick], SERIAL_BAUD); ard.bufferUntil('\\n'); }
+  try { ard = new Serial(this, ports[pick], SERIAL_BAUD); ard.bufferUntil('\n'); }
   catch(Exception e){ println("Serial error: "+e.getMessage()); ard=null; }
 }
 
 void serialEvent(Serial s) {
-  String line = s.readStringUntil('\\n');
+  String line = s.readStringUntil('\n');
   if (line == null) return;
   line = trim(line);
   if (line.length()==0) return;


### PR DESCRIPTION
## Summary
- correct the newline delimiter literals used when buffering and reading serial data in the Processing sketch
- ensure the Serial buffer uses the newline character instead of an invalid two-character literal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc4cf0ac38832597c613920e1ac2e3