### PR TITLE
Document educator mode toggle and refresh changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Changelog
 
-## v2 (current)
+## v2.2 (unreleased)
+- Stabilized camera detection, recording, and save flows so the workshop survives low frame rates and post-capture edge cases.
+- Made the avatar mode reactive, shuffled the face helper tabs for clarity, and dropped fresh UV slug assets for remixing.
+- Expanded the lineage timeline + repo map docs to spotlight the ethical throughline of the build.
+- Documented the Educator Mode toggle with Minnesota standards alignment so teachers can translate the punk brief for admins.
+
+## v2.1.2
 - Added Arduino **long-press** → `CONSENT_TOGGLE`.
 - Added **Session Review** for MP4 keep/discard (auto-delete if not confirmed).
 - Double-press SAVE (≤1s) auto-confirms **only** when Consent is ON.
 - Kept avatar mode, consent gate, feathered mask, and UI buttons.
 
+## v2.1.1 (unreleased)
+- macOS friendly camera picker + permission hints so the sketch behaves on Apple hardware.
+
 ## v2.1
 - Added ConsentDetect teaching sketch (consent gate, TTL, overlay toggle)
 - Added privacy/ethics docs and auto-purge on startup
-
-## v2.1.1 (unreleased)
-- macOS friendly camera picker + permission hints so the sketch behaves on Apple hardware.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ A Processing + Arduino sketch that doubles as a workshop kit on community consen
 
 > Built for STEAM classrooms, community tech clinics, and punk art spaces where ethics, consent, and UX are first-class citizens.
 
+<details markdown="block">
+<summary><strong>Educator Mode — logistics, standards, and clock time</strong></summary>
+
+#### Logistics (what you need to pull this off)
+
+- **Gear:** one webcam-enabled laptop running Processing, optional Arduino button deck, projector if you want the room to debug together.
+- **Printables:** copies of the [Ethics zine](ETHICS.md) + [Privacy brief](PRIVACY.md) so students can annotate instead of doomscrolling.
+- **Room setup:** pods of 2–3 learners with sight lines to the projected screen; tape off a “camera consent zone” so boundaries stay visible.
+
+#### Standards alignment (translate the punk ethos to admin-speak)
+
+- **Minnesota Academic Standards in Science (2019) — Nature of Science and Engineering:** Learners evaluate the societal and ethical trade-offs of proposed engineering solutions when they debate camera usage, retention limits, and consent defaults.
+- **Minnesota Academic Standards in the Arts (Media Arts, 2018):** Students refine media artworks that balance intent, audience, and context by iterating on avatar aesthetics and display choices.
+- **Minnesota Computer Science Standards (2024) — Impacts of Computing:** Facilitators guide students to analyze how computing innovations shape equity, privacy, and security in local communities.
+
+#### Classroom time cost (because bells still ring)
+
+- **Single block:** 55–65 minutes covers the playlist as written with a brisk demo-to-reflection arc.
+- **Two-block deep dive:** 2 × 45 minutes lets you slow down the Arduino build, run peer critiques, and record exit interviews on consent culture.
+- **Prep buffer:** budget 20 minutes before class to verify libraries, clear old captures, and stage the avatar assets.
+
+</details>
+
 ## Workshop playlist
 
 1. **Consent check-in** — Read the [Ethics zine](ETHICS.md) out loud; ask the group who decides when cameras roll.


### PR DESCRIPTION
## Summary
- keep the collapsible Educator Mode block while using markdown-friendly syntax so it renders cleanly across processors
- update the standards alignment callouts to Minnesota state frameworks while tidying the markdown formatting inside the toggle
- refresh the changelog with recent fixes, doc expansions, and educator mode documentation

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68d9b5b893348325bffcc580e368aad5